### PR TITLE
Update frcnn_roi_data_layer.cpp

### DIFF
--- a/src/caffe/FRCNN/frcnn_roi_data_layer.cpp
+++ b/src/caffe/FRCNN/frcnn_roi_data_layer.cpp
@@ -324,6 +324,7 @@ void FrcnnRoiDataLayer<Dtype>::load_batch(Batch<Dtype> *batch) {
 
     if (top_label[5 * i + 3] >= top_label[0]) {
       DLOG(INFO) << mirror << " row : " << src.rows << ",  col : " << src.cols << ", im_scale : " << im_scale << " | " << rois[i-1][DataPrepare::Y2] << " , " << top_label[5 * i + 3];
+      top_label[5 * i + 3] = top_label[0] - 1;
     }
     if (top_label[5 * i + 2] >= top_label[1]) {
       DLOG(INFO) << mirror << " row : " << src.rows << ",  col : " << src.cols << ", im_scale : " << im_scale << " | " << rois[i-1][DataPrepare::X2] << " , " << top_label[5 * i + 2];


### PR DESCRIPTION
I assume, there was a line missing here, that ensures that the y2 coordinate of a roi does not exceed the dimensions of the scaled image.