### PR TITLE
Update frcnn_proposal_layer.cu

### DIFF
--- a/src/caffe/FRCNN/frcnn_proposal_layer.cu
+++ b/src/caffe/FRCNN/frcnn_proposal_layer.cu
@@ -4,7 +4,6 @@
 // Licensed under The MIT License [see fast-rcnn/LICENSE for details]
 // Written by Ross Girshick
 // ------------------------------------------------------------------
-#include <cub/cub.cuh>
 #include <iomanip>
 
 #include "caffe/FRCNN/frcnn_proposal_layer.hpp"


### PR DESCRIPTION
//#include <cub/cub.cuh> is not needed for new cuda 9.2